### PR TITLE
Refactored client

### DIFF
--- a/packages/chakra-components/src/components/Account/Balance.tsx
+++ b/packages/chakra-components/src/components/Account/Balance.tsx
@@ -1,15 +1,8 @@
 import { Tag, TagProps } from '@chakra-ui/tag'
-import { useEffect } from 'react'
 import { useClient } from '../../client'
 
 export const Balance = (props: TagProps) => {
-  const { balance, account, fetchAccount } = useClient()
-
-  useEffect(() => {
-    if (typeof account !== 'undefined') return
-
-    fetchAccount().then(console.log)
-  }, [account])
+  const { balance } = useClient()
 
   if (balance < 0) {
     return null

--- a/packages/chakra-components/src/components/Election/Actions.tsx
+++ b/packages/chakra-components/src/components/Election/Actions.tsx
@@ -2,7 +2,7 @@ import { ButtonGroup, IconButton } from '@chakra-ui/button'
 import { ChakraProps, chakra, useMultiStyleConfig } from '@chakra-ui/system'
 import { ToastId, useToast } from '@chakra-ui/toast'
 import { ElectionStatus } from '@vocdoni/sdk'
-import { useEffect, useRef } from 'react'
+import { useRef } from 'react'
 import { FaPause, FaPlay, FaStop } from 'react-icons/fa'
 import { ImCross } from 'react-icons/im'
 import { useClient } from '../../client'
@@ -16,17 +16,10 @@ const StopIcon = chakra(FaStop)
 
 export const ElectionActions = (props: ChakraProps) => {
   const toast = useToast()
-  const { client, trans, account, fetchAccount } = useClient()
+  const { client, trans, connected, account, fetchAccount } = useClient()
   const { election } = useElection()
   const tRef = useRef<ToastId>()
   const styles = useMultiStyleConfig('ElectionActions')
-
-  // ensure we have account data
-  useEffect(() => {
-    if (typeof account !== 'undefined') return
-
-    fetchAccount()
-  }, [account])
 
   if (!election || (election && !areEqualHexStrings(election.organizationId, account?.address))) return null
 

--- a/packages/chakra-components/src/components/Election/Election.tsx
+++ b/packages/chakra-components/src/components/Election/Election.tsx
@@ -1,6 +1,4 @@
 import { ChakraProps } from '@chakra-ui/system'
-import { Signer } from '@ethersproject/abstract-signer'
-import { Wallet } from '@ethersproject/wallet'
 import { PublishedElection, Vote } from '@vocdoni/sdk'
 import { ComponentType, PropsWithChildren, createContext, useContext, useEffect, useState } from 'react'
 import { FieldValues } from 'react-hook-form'
@@ -21,7 +19,6 @@ import { VoteButton } from './VoteButton'
 export type ElectionProviderProps = {
   id?: string
   election?: PublishedElection
-  signer?: Wallet | Signer
   ConnectButton?: ComponentType
   fetchCensus?: boolean
   beforeSubmit?: (vote: Vote) => boolean
@@ -32,14 +29,13 @@ export type ElectionProviderProps = {
 export const useElectionProvider = ({
   id,
   election: data,
-  signer: s,
   fetchCensus,
   beforeSubmit,
   autoUpdateInterval,
   autoUpdate,
   ...rest
 }: ElectionProviderProps) => {
-  const { client, signer, setSigner, trans } = useClient()
+  const { client, signer, trans } = useClient()
   const [loading, setLoading] = useState<boolean>(false)
   const [voting, setVoting] = useState<boolean>(false)
   const [loaded, setLoaded] = useState<boolean>(false)
@@ -50,14 +46,6 @@ export const useElectionProvider = ({
   const [votesLeft, setVotesLeft] = useState<number>(0)
   const [isInCensus, setIsInCensus] = useState<boolean>(false)
   const [formError, setFormError] = useState<boolean>(false)
-
-  // set signer in case it has been specified in the election
-  // provider (rather than the client provider). Not sure if this is useful tho...
-  useEffect(() => {
-    if (!client || signer || !s) return
-
-    setSigner(s)
-  }, [signer, client, s])
 
   const fetchElection = async (id: string) => {
     setLoading(true)

--- a/packages/chakra-components/src/components/Organization/Organization.tsx
+++ b/packages/chakra-components/src/components/Organization/Organization.tsx
@@ -12,7 +12,7 @@ export type OrganizationProviderProps = {
 }
 
 export const useOrganizationProvider = ({ id, organization }: OrganizationProviderProps) => {
-  const { client, signer, setSigner, account: vAccount } = useClient()
+  const { client, signer, account: vAccount } = useClient()
   const { state, loading, setOrganization, loadError, updateError } = useOrganizationReducer(organization)
 
   // fetches organization info, and sets it to the state

--- a/packages/chakra-components/src/components/Organization/use-organization-reducer.tsx
+++ b/packages/chakra-components/src/components/Organization/use-organization-reducer.tsx
@@ -1,5 +1,6 @@
 import { AccountData } from '@vocdoni/sdk'
 import { Reducer, useReducer } from 'react'
+import { errorToString } from '../../utils'
 
 export const OrganizationLoadError = 'organization:load:error'
 export const OrganizationLoading = 'organization:loading'
@@ -117,23 +118,6 @@ const organizationReducer: Reducer<OrganizationReducerState, OrganizationAction>
   }
 
   return state
-}
-
-/**
- * Theoretically, all errors from the SDK should be returned as strings, but this is not true
- * for any error coming from the signer (which is, in part, coming from the SDK). That's why
- * we need to properly cast them to strings. Note we're not using error instanceof Error because
- * it just not works for many signer errors.
- *
- * @param {Error|string} error The error to be casted
- * @returns {string}
- */
-const errorToString = (error: Error | string): string => {
-  if (typeof error !== 'string' && 'message' in error) {
-    return error.message
-  }
-
-  return error
 }
 
 export const useOrganizationReducer = (organization?: AccountData) => {

--- a/packages/chakra-components/src/use-client-reducer.ts
+++ b/packages/chakra-components/src/use-client-reducer.ts
@@ -1,0 +1,264 @@
+import { Signer } from '@ethersproject/abstract-signer'
+import { Wallet } from '@ethersproject/wallet'
+import { AccountData, EnvOptions, VocdoniSDKClient } from '@vocdoni/sdk'
+import { Reducer, useReducer } from 'react'
+import { ClientProviderProps } from './client'
+import { errorToString } from './utils'
+
+export const ClientAccountError = 'client:account:error'
+export const ClientAccountFetch = 'client:account:fetch'
+export const ClientAccountSet = 'client:account:set'
+export const ClientBalanceError = 'client:balance:error'
+export const ClientBalanceFetch = 'client:balance:fetch'
+export const ClientBalanceSet = 'client:balance:set'
+export const ClientEnvSet = 'client:env:set'
+export const ClientSet = 'client:set'
+export const ClientSignerSet = 'client:signer:set'
+
+type ErrorPayload = Error | string
+
+export type ClientAccountErrorPayload = ErrorPayload
+export type ClientAccountSetPayload = AccountData
+export type ClientBalanceErrorPayload = ErrorPayload
+export type ClientBalanceSetPayload = number
+export type ClientEnvSetPayload = string
+export type ClientSetPayload = VocdoniSDKClient
+export type ClientSignerSetPayload = Signer | Wallet
+
+export type ClientActionPayload =
+  | ClientAccountErrorPayload
+  | ClientAccountSetPayload
+  | ClientBalanceErrorPayload
+  | ClientBalanceSetPayload
+  | ClientEnvSetPayload
+  | ClientSetPayload
+  | ClientSignerSetPayload
+
+export type ClientActionType =
+  | typeof ClientAccountError
+  | typeof ClientAccountFetch
+  | typeof ClientAccountSet
+  | typeof ClientBalanceError
+  | typeof ClientBalanceFetch
+  | typeof ClientBalanceSet
+  | typeof ClientEnvSet
+  | typeof ClientSet
+  | typeof ClientSignerSet
+
+export interface ClientAction {
+  type: ClientActionType
+  payload?: ClientActionPayload
+}
+
+export interface ClientState {
+  client: VocdoniSDKClient
+  env: string
+  account: AccountData | undefined
+  signer: Wallet | Signer
+  balance: number
+  // determines if a wallet is connected to the client
+  connected: boolean
+  // loaded status
+  loaded: {
+    account: boolean
+    balance: boolean
+  }
+  // loading status
+  loading: {
+    account: boolean
+    balance: boolean
+  }
+  errors: {
+    account: string | null
+    balance: string | null
+  }
+}
+
+export const clientStateEmpty = (env: string, signer: Wallet | Signer): ClientState => ({
+  env,
+  signer,
+  client: new VocdoniSDKClient({
+    env: EnvOptions.DEV,
+  }),
+  account: undefined,
+  balance: -1,
+  connected: false,
+  loading: {
+    account: false,
+    balance: false,
+  },
+  loaded: {
+    account: false,
+    balance: false,
+  },
+  errors: {
+    account: null,
+    balance: null,
+  },
+})
+
+const clientReducer: Reducer<ClientState, ClientAction> = (state: ClientState, action: ClientAction) => {
+  switch (action.type) {
+    case ClientAccountFetch: {
+      return {
+        ...state,
+        loading: {
+          ...state.loading,
+          account: true,
+        },
+      }
+    }
+    case ClientAccountError: {
+      const error = action.payload as ClientAccountErrorPayload
+      return {
+        ...state,
+        loading: {
+          ...state.loading,
+          account: false,
+        },
+        loaded: {
+          ...state.loaded,
+          account: true,
+        },
+        errors: {
+          ...state.errors,
+          account: errorToString(error),
+        },
+      }
+    }
+    case ClientAccountSet: {
+      const account = action.payload as ClientAccountSetPayload
+      return {
+        ...state,
+        account,
+        loading: {
+          ...state.loading,
+          account: false,
+        },
+        loaded: {
+          ...state.loaded,
+          account: true,
+        },
+        errors: {
+          ...state.errors,
+          account: null,
+        },
+      }
+    }
+    case ClientBalanceError: {
+      const error = action.payload as ClientBalanceErrorPayload
+      return {
+        ...state,
+        loading: {
+          ...state.loading,
+          balance: false,
+        },
+        loaded: {
+          ...state.loaded,
+          balance: true,
+        },
+        errors: {
+          ...state.errors,
+          balance: errorToString(error),
+        },
+      }
+    }
+    case ClientBalanceFetch: {
+      return {
+        ...state,
+        loading: {
+          ...state.loading,
+          balance: true,
+        },
+      }
+    }
+    case ClientBalanceSet: {
+      const balance = action.payload as ClientBalanceSetPayload
+      return {
+        ...state,
+        balance,
+        loading: {
+          ...state.loading,
+          balance: false,
+        },
+        loaded: {
+          ...state.loaded,
+          balance: true,
+        },
+        errors: {
+          ...state.errors,
+          balance: null,
+        },
+      }
+    }
+    case ClientSet: {
+      const client = action.payload as ClientSetPayload
+      return {
+        ...state,
+        client,
+        connected: !!client.wallet,
+      }
+    }
+    case ClientEnvSet: {
+      const env = action.payload as ClientEnvSetPayload
+      // redefine client to use new environment
+      const client = new VocdoniSDKClient({
+        env: env as EnvOptions,
+        wallet: state.signer,
+      })
+      return {
+        ...state,
+        account: undefined,
+        balance: -1,
+        client,
+        env,
+        connected: !!client.wallet,
+      }
+    }
+    case ClientSignerSet: {
+      const signer = action.payload as ClientSignerSetPayload
+      const client = new VocdoniSDKClient({
+        env: state.env as EnvOptions,
+        wallet: signer,
+      })
+      return {
+        ...state,
+        client,
+        signer,
+        connected: !!client.wallet,
+      }
+    }
+  }
+  return state
+}
+
+export const useClientReducer = ({ env, client, signer }: ClientProviderProps) => {
+  const [state, dispatch] = useReducer(clientReducer, clientStateEmpty(env as string, signer as Wallet | Signer))
+
+  // dispatch helper methods
+  const setAccount = (account: AccountData | undefined) => dispatch({ type: ClientAccountSet, payload: account })
+  const setBalance = (balance: number) => dispatch({ type: ClientBalanceSet, payload: balance })
+  const fetchAccount = () => dispatch({ type: ClientAccountFetch })
+  const fetchBalance = () => dispatch({ type: ClientBalanceFetch })
+  const errorBalance = (error: Error | string) => dispatch({ type: ClientBalanceError, payload: error })
+  const errorAccount = (error: Error | string) => dispatch({ type: ClientAccountError, payload: error })
+  const setClient = (client: VocdoniSDKClient) => dispatch({ type: ClientSet, payload: client })
+  const setEnv = (env: string) => dispatch({ type: ClientEnvSet, payload: env })
+  const setSigner = (signer: Wallet | Signer) => dispatch({ type: ClientSignerSet, payload: signer })
+
+  return {
+    state,
+    dispatch,
+    actions: {
+      errorAccount,
+      errorBalance,
+      fetchAccount,
+      fetchBalance,
+      setAccount,
+      setBalance,
+      setClient,
+      setEnv,
+      setSigner,
+    },
+  }
+}

--- a/packages/chakra-components/src/utils.ts
+++ b/packages/chakra-components/src/utils.ts
@@ -21,3 +21,20 @@ export const areEqualHexStrings = (hex1?: string, hex2?: string) => {
 
   return enforceHexPrefix(hex1.toLocaleLowerCase()) === enforceHexPrefix(hex2.toLowerCase())
 }
+
+/**
+ * Theoretically, all errors from the SDK should be returned as strings, but this is not true
+ * for any error coming from the signer (which is, in part, coming from the SDK). That's why
+ * we need to properly cast them to strings. Note we're not using error instanceof Error because
+ * it just not works for many signer errors.
+ *
+ * @param {Error|string} error The error to be casted
+ * @returns {string}
+ */
+export const errorToString = (error: Error | string): string => {
+  if (typeof error !== 'string' && 'message' in error) {
+    return error.message
+  }
+
+  return error
+}


### PR DESCRIPTION
- created reducer for a better state management
- fixed account info not being retrieved again on wallet change
- fixed account balance not being retrieved again on wallet change
- client provider now makes fetchAccount calls in case you connect a signer, so there should be no need to call fetchAccount nor fetchBalance when creating related account components
- fixed environment change was not updating client
- probably more fixes related to state, although that can mean I may have added an error or two (I hope not TBH)
- removed unnecessary signer logic in election provider

closes #43 
