### PR TITLE
F/wallets new transport

### DIFF
--- a/packages/rainbowkit-wallets/src/lib/inputsWallet.tsx
+++ b/packages/rainbowkit-wallets/src/lib/inputsWallet.tsx
@@ -1,8 +1,7 @@
 import { createRoot } from 'react-dom/client'
-import { WalletClient } from 'viem'
 import { CreateWalletModal } from '../components/CreateWalletModal'
 import localStorageWallet from './localStorageWallet'
-import { PublicClient } from 'wagmi'
+import { PublicClient, WalletClient } from 'wagmi'
 
 /**
  * This class is used to create a wallet from a form

--- a/packages/rainbowkit-wallets/src/lib/inputsWallet.tsx
+++ b/packages/rainbowkit-wallets/src/lib/inputsWallet.tsx
@@ -1,8 +1,8 @@
 import { createRoot } from 'react-dom/client'
 import { WalletClient } from 'viem'
-import { WindowProvider } from 'wagmi'
 import { CreateWalletModal } from '../components/CreateWalletModal'
 import localStorageWallet from './localStorageWallet'
+import { PublicClient } from 'wagmi'
 
 /**
  * This class is used to create a wallet from a form
@@ -11,7 +11,7 @@ export class inputsWallet extends localStorageWallet {
   private data: any
   private cancel: boolean = false
 
-  async create(provider: WindowProvider): Promise<WalletClient> {
+  async create(provider: PublicClient): Promise<WalletClient> {
     // Create a div to render the modal
     const myDiv = document.createElement('div')
     myDiv.setAttribute('id', 'myDiv' + Math.random())

--- a/packages/rainbowkit-wallets/src/lib/localStorageWallet.ts
+++ b/packages/rainbowkit-wallets/src/lib/localStorageWallet.ts
@@ -1,22 +1,22 @@
 import { Buffer } from 'buffer'
-import { createWalletClient, custom, keccak256, WalletClient, publicActions } from 'viem'
+import { createWalletClient, custom, keccak256, publicActions } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { PublicClient, mainnet } from 'wagmi'
+import { PublicClient, mainnet, WalletClient } from 'wagmi'
 
 export default class localStorageWallet {
   static storageItemName = 'localstorage-wallet-seed'
 
-  public static async getWallet(provider: PublicClient): Promise<WalletClient | undefined> {
+  public static async getWallet(provider: PublicClient): Promise<WalletClient> {
     try {
       const value: string = localStorage.getItem(this.storageItemName) as string
-      if (!value) return undefined
+      if (!value) throw new Error('no wallet found')
 
       return this.createWallet(value, provider)
     } catch (err) {
       console.error('failed to generate wallet:', err)
     }
 
-    return undefined
+    throw new Error('could not find or create wallet')
   }
 
   public static async createWallet(data: string | string[], provider: PublicClient): Promise<WalletClient> {

--- a/packages/rainbowkit-wallets/src/lib/localStorageWallet.ts
+++ b/packages/rainbowkit-wallets/src/lib/localStorageWallet.ts
@@ -1,6 +1,6 @@
 import { WindowProvider } from '@wagmi/connectors'
 import { Buffer } from 'buffer'
-import { createWalletClient, custom, keccak256, WalletClient } from 'viem'
+import { createWalletClient, custom, keccak256, WalletClient, publicActions } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { mainnet } from 'wagmi'
 
@@ -31,7 +31,7 @@ export default class localStorageWallet {
       account,
       chain: mainnet,
       transport: custom(provider),
-    })
+    }).extend(publicActions)
 
     return client
   }

--- a/packages/rainbowkit-wallets/src/lib/localStorageWallet.ts
+++ b/packages/rainbowkit-wallets/src/lib/localStorageWallet.ts
@@ -1,13 +1,12 @@
-import { WindowProvider } from '@wagmi/connectors'
 import { Buffer } from 'buffer'
 import { createWalletClient, custom, keccak256, WalletClient, publicActions } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { mainnet } from 'wagmi'
+import { PublicClient, mainnet } from 'wagmi'
 
 export default class localStorageWallet {
   static storageItemName = 'localstorage-wallet-seed'
 
-  public static async getWallet(provider: WindowProvider): Promise<WalletClient | undefined> {
+  public static async getWallet(provider: PublicClient): Promise<WalletClient | undefined> {
     try {
       const value: string = localStorage.getItem(this.storageItemName) as string
       if (!value) return undefined
@@ -20,7 +19,7 @@ export default class localStorageWallet {
     return undefined
   }
 
-  public static async createWallet(data: string | string[], provider: WindowProvider): Promise<WalletClient> {
+  public static async createWallet(data: string | string[], provider: PublicClient): Promise<WalletClient> {
     const inputs = Array.isArray(data) ? data : [data]
     const hash = inputs.reduce((acc, curr) => acc + curr, '')
 
@@ -30,7 +29,35 @@ export default class localStorageWallet {
     const client = createWalletClient({
       account,
       chain: mainnet,
-      transport: custom(provider),
+      transport: custom({
+        async request({ method, params }) {
+          switch (method) {
+            case 'eth_accounts':
+              return [account.address]
+            case 'net_version':
+            case 'eth_chainId':
+              return `0x${mainnet.id}`
+            case 'personal_sign': {
+              const [message, address] = params
+              return (await account.signMessage({ message })) || '0x'
+            }
+            case 'eth_sign': {
+              const [address, messageHash] = params
+              return (await account.signMessage({ message: messageHash })) || '0x'
+            }
+            case 'eth_signTypedData':
+            case 'eth_signTypedData_v4': {
+              const [address, typedData] = params
+              const parsedTypedData = typeof typedData === 'string' ? JSON.parse(typedData) : typedData
+
+              const signature = await account.signTypedData(parsedTypedData)
+              return signature || '0x'
+            }
+            default:
+              provider.request({ method, params })
+          }
+        },
+      }),
     }).extend(publicActions)
 
     return client

--- a/packages/rainbowkit-wallets/src/lib/oAuthWallet.tsx
+++ b/packages/rainbowkit-wallets/src/lib/oAuthWallet.tsx
@@ -1,6 +1,5 @@
-import { WalletClient } from 'viem'
 import localStorageWallet from './localStorageWallet'
-import { PublicClient } from 'wagmi'
+import { PublicClient, WalletClient } from 'wagmi'
 
 /**
  * This class is used to create a wallet from an external service (OAuth)

--- a/packages/rainbowkit-wallets/src/lib/oAuthWallet.tsx
+++ b/packages/rainbowkit-wallets/src/lib/oAuthWallet.tsx
@@ -1,6 +1,6 @@
-import { WindowProvider } from '@wagmi/connectors'
 import { WalletClient } from 'viem'
 import localStorageWallet from './localStorageWallet'
+import { PublicClient } from 'wagmi'
 
 /**
  * This class is used to create a wallet from an external service (OAuth)
@@ -18,7 +18,7 @@ export class oAuthWallet extends localStorageWallet {
     this.oAuthServiceProvider = oAuthServiceProvider
   }
 
-  async create(provider: WindowProvider): Promise<WalletClient> {
+  async create(provider: PublicClient): Promise<WalletClient> {
     // Open the login popup
     const url = this.oAuthServiceUrl + (this.oAuthServiceProvider ? `?provider=${this.oAuthServiceProvider}` : '')
     this.openLoginPopup(url)

--- a/packages/rainbowkit-wallets/src/wagmi/inputsConnector.ts
+++ b/packages/rainbowkit-wallets/src/wagmi/inputsConnector.ts
@@ -1,6 +1,6 @@
-import { WindowProvider } from '@wagmi/connectors'
 import { inputsWallet } from '../lib/inputsWallet'
 import { localStorageConnector } from './localStorageConnector'
+import { PublicClient } from 'wagmi'
 
 const IS_SERVER = typeof window === 'undefined'
 
@@ -10,7 +10,7 @@ export class inputsConnector extends localStorageConnector {
   readonly name = 'Inputs'
 
   protected async createWallet() {
-    const provider = (await this.getProvider()) as WindowProvider
+    const provider = (await this.getProvider()) as PublicClient
     let wallet = await inputsWallet.getWallet(provider)
     if (!wallet) {
       const w = new inputsWallet()

--- a/packages/rainbowkit-wallets/src/wagmi/inputsConnector.ts
+++ b/packages/rainbowkit-wallets/src/wagmi/inputsConnector.ts
@@ -17,6 +17,6 @@ export class inputsConnector extends localStorageConnector {
       wallet = await w.create(provider)
     }
 
-    this.wallet = wallet?.account
+    this.wallet = wallet
   }
 }

--- a/packages/rainbowkit-wallets/src/wagmi/localStorageConnector.ts
+++ b/packages/rainbowkit-wallets/src/wagmi/localStorageConnector.ts
@@ -1,15 +1,6 @@
-import {
-  type Address,
-  UserRejectedRequestError,
-  getAddress,
-  Account,
-  Chain,
-  createPublicClient,
-  http,
-  WalletClient,
-} from 'viem'
+import { type Address, UserRejectedRequestError, getAddress, Account, Chain, createPublicClient, http } from 'viem'
 import { mainnet } from 'viem/chains'
-import { ConnectorData, ConnectorNotFoundError, PublicClient } from 'wagmi'
+import { ConnectorData, ConnectorNotFoundError, PublicClient, WalletClient } from 'wagmi'
 import { Connector, normalizeChainId } from '@wagmi/connectors'
 import localStorageWallet from '../lib/localStorageWallet'
 
@@ -107,6 +98,8 @@ export class localStorageConnector extends Connector {
   async getWalletClient({ chainId }: { chainId: number }) {
     const provider = await this.getProvider()
     if (!provider) throw new ConnectorNotFoundError()
+    const account = await this.getAccount()
+    if (!account) throw new ConnectorNotFoundError()
 
     let wallet = await localStorageWallet.getWallet(provider)
     if (!wallet) throw new ConnectorNotFoundError()

--- a/packages/rainbowkit-wallets/src/wagmi/localStorageConnector.ts
+++ b/packages/rainbowkit-wallets/src/wagmi/localStorageConnector.ts
@@ -9,7 +9,7 @@ import {
   WalletClient,
 } from 'viem'
 import { mainnet } from 'viem/chains'
-import { ConnectorData, ConnectorNotFoundError, WindowProvider } from 'wagmi'
+import { ConnectorData, ConnectorNotFoundError, PublicClient } from 'wagmi'
 import { Connector, normalizeChainId } from '@wagmi/connectors'
 import localStorageWallet from '../lib/localStorageWallet'
 
@@ -24,7 +24,7 @@ export class localStorageConnector extends Connector {
   readonly name: string = 'localStorage'
 
   protected chainId: number | undefined
-  protected provider: WindowProvider | undefined
+  protected provider: PublicClient | undefined
   protected wallet: WalletClient | undefined
 
   constructor(config: { chains: Chain[]; options: any }) {

--- a/packages/rainbowkit-wallets/src/wagmi/localStorageConnector.ts
+++ b/packages/rainbowkit-wallets/src/wagmi/localStorageConnector.ts
@@ -1,7 +1,16 @@
-import { normalizeChainId, WindowProvider } from '@wagmi/connectors'
-import { InjectedConnector } from '@wagmi/connectors/injected'
-import { Account, Chain, getAddress, UserRejectedRequestError, type Address } from 'viem'
-import { ConnectorData, ConnectorNotFoundError } from 'wagmi'
+import {
+  type Address,
+  UserRejectedRequestError,
+  getAddress,
+  Account,
+  Chain,
+  createPublicClient,
+  http,
+  WalletClient,
+} from 'viem'
+import { mainnet } from 'viem/chains'
+import { ConnectorData, ConnectorNotFoundError, WindowProvider } from 'wagmi'
+import { Connector, normalizeChainId } from '@wagmi/connectors'
 import localStorageWallet from '../lib/localStorageWallet'
 
 const IS_SERVER = typeof window === 'undefined'
@@ -9,14 +18,14 @@ const IS_SERVER = typeof window === 'undefined'
 /**
  * A connector that uses the local storage to store seed for a deterministic wallet generation
  */
-export class localStorageConnector extends InjectedConnector {
+export class localStorageConnector extends Connector {
   ready = !IS_SERVER
   readonly id: string = 'localStorageConnector'
   readonly name: string = 'localStorage'
 
   protected chainId: number | undefined
   protected provider: WindowProvider | undefined
-  protected wallet: Account | undefined
+  protected wallet: WalletClient | undefined
 
   constructor(config: { chains: Chain[]; options: any }) {
     super(config)
@@ -58,7 +67,19 @@ export class localStorageConnector extends InjectedConnector {
   }
 
   async getSigner(): Promise<Account | undefined> {
-    return this.wallet
+    if (!this.wallet) return undefined
+    return this.wallet.account
+  }
+
+  async getProvider() {
+    if (!this.provider) {
+      this.provider = createPublicClient({
+        chain: mainnet,
+        transport: http(),
+      })
+    }
+
+    return this.provider
   }
 
   async getChainId() {
@@ -77,10 +98,21 @@ export class localStorageConnector extends InjectedConnector {
     let wallet = await localStorageWallet.getWallet(provider)
     if (!wallet) return false
 
-    this.wallet = wallet.account
+    this.wallet = wallet
 
     const account = await this.getAccount()
     return !!account
+  }
+
+  async getWalletClient({ chainId }: { chainId: number }) {
+    const provider = await this.getProvider()
+    if (!provider) throw new ConnectorNotFoundError()
+
+    let wallet = await localStorageWallet.getWallet(provider)
+    if (!wallet) throw new ConnectorNotFoundError()
+
+    this.wallet = wallet
+    return this.wallet
   }
 
   onDisconnect = async (error: Error): Promise<void> => {

--- a/packages/rainbowkit-wallets/src/wagmi/oAuthConnector.ts
+++ b/packages/rainbowkit-wallets/src/wagmi/oAuthConnector.ts
@@ -1,5 +1,4 @@
-import { WindowProvider } from '@wagmi/connectors'
-import { Chain } from 'wagmi'
+import { Chain, PublicClient } from 'wagmi'
 import { oAuthWallet } from '../lib/oAuthWallet'
 import { localStorageConnector } from './localStorageConnector'
 
@@ -28,7 +27,7 @@ export class oAuthConnector extends localStorageConnector {
   }
 
   protected async createWallet() {
-    const provider = (await this.getProvider()) as WindowProvider
+    const provider = (await this.getProvider()) as PublicClient
     let wallet = await oAuthWallet.getWallet(provider)
 
     if (!wallet) {

--- a/packages/rainbowkit-wallets/src/wagmi/oAuthConnector.ts
+++ b/packages/rainbowkit-wallets/src/wagmi/oAuthConnector.ts
@@ -30,11 +30,12 @@ export class oAuthConnector extends localStorageConnector {
   protected async createWallet() {
     const provider = (await this.getProvider()) as WindowProvider
     let wallet = await oAuthWallet.getWallet(provider)
+
     if (!wallet) {
       const w = new oAuthWallet(this.oAuthServiceUrl, this.oAuthServiceProvider)
       wallet = await w.create(provider)
     }
 
-    this.wallet = wallet?.account
+    this.wallet = wallet
   }
 }


### PR DESCRIPTION
In order to "bugfix" the viem -> ethersjs rainbowkit wallet conversion, I've created a new transport, so it does the signatures in memory (not sending the request to RPC)