### PR TITLE
Returning false when no wallet is found

### DIFF
--- a/packages/rainbowkit-wallets/src/lib/localStorageWallet.ts
+++ b/packages/rainbowkit-wallets/src/lib/localStorageWallet.ts
@@ -6,10 +6,10 @@ import { PublicClient, mainnet, WalletClient } from 'wagmi'
 export default class localStorageWallet {
   static storageItemName = 'localstorage-wallet-seed'
 
-  public static async getWallet(provider: PublicClient): Promise<WalletClient> {
+  public static async getWallet(provider: PublicClient): Promise<WalletClient | false> {
     try {
       const value: string = localStorage.getItem(this.storageItemName) as string
-      if (!value) throw new Error('no wallet found')
+      if (!value) return false
 
       return this.createWallet(value, provider)
     } catch (err) {

--- a/packages/rainbowkit-wallets/src/wagmi/inputsConnector.ts
+++ b/packages/rainbowkit-wallets/src/wagmi/inputsConnector.ts
@@ -1,6 +1,6 @@
 import { inputsWallet } from '../lib/inputsWallet'
 import { localStorageConnector } from './localStorageConnector'
-import { PublicClient } from 'wagmi'
+import { PublicClient, WalletClient } from 'wagmi'
 
 const IS_SERVER = typeof window === 'undefined'
 
@@ -17,6 +17,6 @@ export class inputsConnector extends localStorageConnector {
       wallet = await w.create(provider)
     }
 
-    this.wallet = wallet
+    this.wallet = wallet as WalletClient
   }
 }

--- a/packages/rainbowkit-wallets/src/wagmi/localStorageConnector.ts
+++ b/packages/rainbowkit-wallets/src/wagmi/localStorageConnector.ts
@@ -89,7 +89,7 @@ export class localStorageConnector extends Connector {
     let wallet = await localStorageWallet.getWallet(provider)
     if (!wallet) return false
 
-    this.wallet = wallet
+    this.wallet = wallet as WalletClient
 
     const account = await this.getAccount()
     return !!account
@@ -104,7 +104,7 @@ export class localStorageConnector extends Connector {
     let wallet = await localStorageWallet.getWallet(provider)
     if (!wallet) throw new ConnectorNotFoundError()
 
-    this.wallet = wallet
+    this.wallet = wallet as WalletClient
     return this.wallet
   }
 

--- a/packages/rainbowkit-wallets/src/wagmi/oAuthConnector.ts
+++ b/packages/rainbowkit-wallets/src/wagmi/oAuthConnector.ts
@@ -1,4 +1,4 @@
-import { Chain, PublicClient } from 'wagmi'
+import { Chain, PublicClient, WalletClient } from 'wagmi'
 import { oAuthWallet } from '../lib/oAuthWallet'
 import { localStorageConnector } from './localStorageConnector'
 
@@ -35,6 +35,6 @@ export class oAuthConnector extends localStorageConnector {
       wallet = await w.create(provider)
     }
 
-    this.wallet = wallet
+    this.wallet = wallet as WalletClient
   }
 }


### PR DESCRIPTION
Not finding a wallet is not unexpected or an error. Makes no sense throwing an exception, so I've removed it.
The unhandled exception was breaking the autoconnect (and other) flows.