### PR TITLE
Delete abstain option

### DIFF
--- a/packages/chakra-components/src/components/Election/Questions.tsx
+++ b/packages/chakra-components/src/components/Election/Questions.tsx
@@ -289,7 +289,7 @@ const MultiChoice = ({ index, question }: QuestionProps) => {
         rules={{
           validate: (v) => {
             // allow a single selection if is an abstain
-            if (canAbstain && v.length < election.voteType.maxCount!) return true
+            if (canAbstain && v && v.length < election.voteType.maxCount!) return true
 
             return (
               (v && v.length === election.voteType.maxCount) ||

--- a/packages/chakra-components/src/components/Election/Questions.tsx
+++ b/packages/chakra-components/src/components/Election/Questions.tsx
@@ -86,8 +86,7 @@ export const ElectionQuestions = (props: ElectionQuestionsProps) => {
           .pop()
           .map((v: string) => parseInt(v, 10))
         // map proper abstain ids
-        if (results.includes(-1)) {
-          results.splice(results.indexOf(-1), 1)
+        if (election.resultsType.properties.canAbstain && results.length < election.voteType.maxCount!) {
           let abs = 0
           while (results.length < (election.voteType.maxCount || 1)) {
             results.push(parseInt(election.resultsType.properties.abstainValues[abs++], 10))
@@ -280,14 +279,7 @@ const MultiChoice = ({ index, question }: QuestionProps) => {
   }
 
   const choices = [...question.choices]
-  if (election.resultsType.properties.canAbstain) {
-    choices.push({
-      title: {
-        default: localize('vote.abstain'),
-      },
-      value: -1,
-    })
-  }
+  const canAbstain = election.resultsType.properties.canAbstain
 
   return (
     <Stack sx={styles.stack}>
@@ -297,7 +289,7 @@ const MultiChoice = ({ index, question }: QuestionProps) => {
         rules={{
           validate: (v) => {
             // allow a single selection if is an abstain
-            if (v.includes('-1') && v.length < election.voteType.maxCount!) return true
+            if (canAbstain && v.length < election.voteType.maxCount!) return true
 
             return (
               (v && v.length === election.voteType.maxCount) ||
@@ -316,15 +308,6 @@ const MultiChoice = ({ index, question }: QuestionProps) => {
                 const maxSelected =
                   currentValues.length >= election.voteType.maxCount! &&
                   !currentValues.includes(choice.value.toString())
-                let abstainScore = null
-                // If is abstain option, show the number of votes that the abstain option will be worth
-                // The maximum number shown will be the maxCount of the election (in case any other option is selected)
-                if (choice.value === -1) {
-                  abstainScore =
-                    currentValues.length === 0
-                      ? election.voteType.maxCount!
-                      : election.voteType.maxCount! - currentValues.length + 1
-                }
                 return (
                   <Checkbox
                     {...restField}
@@ -344,8 +327,6 @@ const MultiChoice = ({ index, question }: QuestionProps) => {
                     }}
                   >
                     {choice.title.default}
-                    {/*Abstain badge to count number of remaining votes to abstain*/}
-                    {abstainScore && <chakra.div __css={styles.abstainBadge}>{abstainScore}</chakra.div>}
                   </Checkbox>
                 )
               })}

--- a/packages/chakra-components/src/components/Election/Questions.tsx
+++ b/packages/chakra-components/src/components/Election/Questions.tsx
@@ -279,6 +279,7 @@ const MultiChoice = ({ index, question }: QuestionProps) => {
   }
 
   const choices = [...question.choices]
+  // Put can abstain on a separated variable to avoid typing errors on validation function
   const canAbstain = election.resultsType.properties.canAbstain
 
   return (

--- a/packages/chakra-components/src/theme/questions.ts
+++ b/packages/chakra-components/src/theme/questions.ts
@@ -28,8 +28,6 @@ export const questionsAnatomy = [
   // form radio and checkboxes
   'radio',
   'checkbox',
-  // Abstain badge to count number of remaining votes to abstain
-  'abstainBadge',
   // form error message
   'error',
 ]
@@ -66,9 +64,6 @@ const baseStyle = definePartsStyle({
   },
   description: {
     marginBottom: 4,
-  },
-  abstainBadge: {
-    ml: '5px',
   },
 })
 


### PR DESCRIPTION
Abstain option and badge are not shown anymore. 

Instead, if abstain is possible, you can just continue selecting only zero or n options. 

A warning message will appear on confirmation modal.

![image](https://github.com/vocdoni/ui-components/assets/16777076/c7a30356-d48b-4cae-9499-f97b13fd1961)

Implemented on https://github.com/vocdoni/ui-scaffold/pull/648

If less options than max are chosen, it will add the abstain choices to the ballor