### PR TITLE
Implement Vocdoni blind csp

### DIFF
--- a/packages/chakra-components/src/components/Election/VoteButton.tsx
+++ b/packages/chakra-components/src/components/Election/VoteButton.tsx
@@ -12,6 +12,7 @@ export const VoteButton = (props: ButtonProps) => {
   const { connected } = useClient()
   const {
     client,
+    connected: elConnected,
     loading: { voting },
     ConnectButton,
     isAbleToVote,
@@ -29,7 +30,7 @@ export const VoteButton = (props: ButtonProps) => {
 
   const isDisabled = !client.wallet || !isAbleToVote || election.status !== ElectionStatus.ONGOING
 
-  if (!connected && election.get('census.type') !== 'spreadsheet' && ConnectButton) {
+  if (!connected && !elConnected && ConnectButton) {
     return <ConnectButton />
   }
 

--- a/packages/react-providers/src/election/use-election-provider.ts
+++ b/packages/react-providers/src/election/use-election-provider.ts
@@ -17,7 +17,7 @@ import { useClient } from '../client'
 import worker, { ICircuit, ICircuitWorkerRequest } from '../worker/circuitWorkerScript'
 import { useWebWorker } from '../worker/useWebWorker'
 import { createWebWorker } from '../worker/webWorker'
-import { useElectionReducer } from './use-election-reducer'
+import { BlindCspServiceKey, useElectionReducer } from './use-election-reducer'
 
 export type ElectionProviderProps = {
   id?: string
@@ -337,7 +337,7 @@ export const useElectionProvider = ({
       throw new Error('not a CSP election')
     }
     switch (service) {
-      case 'vocdoni-blind-csp':
+      case BlindCspServiceKey:
         return blindCspVote()
       default:
         return cspAuthAndVote()
@@ -465,7 +465,7 @@ export const useElectionProvider = ({
     try {
       const walletAddress: string = (await client.wallet?.getAddress()) as string
       const signature: string = await client.cspSign(walletAddress, token)
-      const cspVote: CspVote = client.cspVote(vote as Vote, signature)
+      const cspVote: CspVote = client.cspVote(vote, signature)
       const vid: string = await client.submitVote(cspVote)
       actions.voted(vid)
     } catch (e) {

--- a/packages/react-providers/src/election/use-election-provider.ts
+++ b/packages/react-providers/src/election/use-election-provider.ts
@@ -338,22 +338,18 @@ export const useElectionProvider = ({
     }
     switch (service) {
       case 'vocdoni-blind-csp':
-        blindCspVote()
-        break
+        return blindCspVote()
       default:
-        cspAuthAndVote()
+        return cspAuthAndVote()
     }
   }
 
   // CSP generic steps
-  const cspStep0 = async (handler: string, data: any[], cb?: (step0: ICspIntermediateStepResponse) => void) => {
+  const cspStep0 = async (handler: string, data: any[]) => {
     let step0: ICspIntermediateStepResponse
     try {
       step0 = (await client.cspStep(0, data)) as ICspIntermediateStepResponse
       actions.csp0({ handler, token: step0.authToken })
-      if (cb) {
-        cb(step0)
-      }
       return step0
     } catch (e) {
       actions.votingError(e)
@@ -404,9 +400,10 @@ export const useElectionProvider = ({
     const redirectURL: string = `${window.location.origin}${window.location.pathname}?${params.toString()}${
       window.location.hash
     }`
-    await cspStep0(handler, [handler, redirectURL], (step0) => {
+    const step0 = await cspStep0(handler, [handler, redirectURL])
+    if (step0) {
       openLoginPopup(handler, step0['response'][0])
-    })
+    }
   }
 
   // CSP OAuth flow


### PR DESCRIPTION
The flow of CSP is modified to support the blind csp implemented by vocdoni. 

The difference with the others CSP is that the step0 uses a random name and the step1 is the resolution of a sum (instead of login on external provider).

This is needed to implement demo pages. 
