### PR TITLE
Delete deprecated function

### DIFF
--- a/packages/extended-sdk/src/client/index.ts
+++ b/packages/extended-sdk/src/client/index.ts
@@ -1,5 +1,4 @@
 import {
-  AccountAPI,
   ChainAPI,
   ElectionAPI,
   IChainBlockInfoResponse,
@@ -24,8 +23,6 @@ export class ExtendedSDKClient extends VocdoniSDKClient {
   organizationList = (page?: number, organizationId?: string) =>
     ChainAPI.organizationList(this.url, page, organizationId)
   organizationCount = () => ChainAPI.organizationCount(this.url)
-  organizationElectionsList = (organizationId: string, page?: number) =>
-    AccountAPI.electionsList(this.url, organizationId, page)
   validatorsList = () => ChainAPI.validatorsList(this.url)
   chainInfo = () => ChainAPI.info(this.url)
   blockByHash = (hash: string) => ChainAPI.blockByHash(this.url, hash)


### PR DESCRIPTION
Old `organizationElectionsList` is now implemented on the SDK on `fetchElections` function.