### PR TITLE
Implement BlockNotFoundError

### DIFF
--- a/packages/extended-sdk/src/client/index.ts
+++ b/packages/extended-sdk/src/client/index.ts
@@ -38,16 +38,6 @@ export class ExtendedSDKClient extends VocdoniSDKClient {
     })
   blockTransactions = (height: number, page?: number) => ChainAPI.blockTransactions(this.url, height, page)
 
-  // blockByHeight = async (height: number): Promise<IChainBlockInfoResponse | BlockNotFoundError> => {
-  //   try {
-  //     return await ChainAPI.blockByHeight(this.url, height)
-  //   } catch (error) {
-  //     if (error instanceof ErrAPI && error.raw?.response?.status === 404) {
-  //       return { height } as BlockNotFoundError
-  //     }
-  //     throw error // re-throw other errors
-  //   }
-  // }
   blockByHeight = (height: number) => ChainAPI.blockByHeight(this.url, height)
 
   blockList = (from: number, listSize: number = 10): Promise<Array<IChainBlockInfoResponse | BlockNotFoundError>> => {
@@ -55,20 +45,21 @@ export class ExtendedSDKClient extends VocdoniSDKClient {
     // If is not a number bigger than 0
     if (isNaN(from)) return Promise.all(promises)
     for (let i = 0; i < listSize; i++) {
-      if (from + i > 0)
-        promises.push(
-          (async () => {
-            try {
-              return await this.blockByHeight(from + i)
-            } catch (error) {
-              if (error instanceof ErrAPI && error.raw?.response?.status === 404) {
-                return { height: from + i } as BlockNotFoundError
-              }
-              throw error // re-throw other errors
+      if (from + i <= 0) continue
+      promises.push(
+        (async () => {
+          try {
+            return await this.blockByHeight(from + i)
+          } catch (error) {
+            if (error instanceof ErrAPI && error.raw?.response?.status === 404) {
+              return { height: from + i } as BlockNotFoundError
             }
-          })()
-        )
+            throw error // re-throw other errors
+          }
+        })()
+      )
     }
+
     return Promise.all(promises).then((blockInfo) => {
       // flatten the array[][] into array[]
       // @ts-ignore

--- a/packages/extended-sdk/src/client/index.ts
+++ b/packages/extended-sdk/src/client/index.ts
@@ -1,6 +1,7 @@
 import {
   ChainAPI,
   ElectionAPI,
+  ErrAPI,
   IChainBlockInfoResponse,
   IElectionListFilter,
   VocdoniSDKClient,
@@ -36,14 +37,37 @@ export class ExtendedSDKClient extends VocdoniSDKClient {
       ...filters,
     })
   blockTransactions = (height: number, page?: number) => ChainAPI.blockTransactions(this.url, height, page)
+
+  // blockByHeight = async (height: number): Promise<IChainBlockInfoResponse | BlockNotFoundError> => {
+  //   try {
+  //     return await ChainAPI.blockByHeight(this.url, height)
+  //   } catch (error) {
+  //     if (error instanceof ErrAPI && error.raw?.response?.status === 404) {
+  //       return { height } as BlockNotFoundError
+  //     }
+  //     throw error // re-throw other errors
+  //   }
+  // }
   blockByHeight = (height: number) => ChainAPI.blockByHeight(this.url, height)
-  // todo: this method will be fixed backend side, see https://github.com/vocdoni/interoperability/issues/33
-  blockList = (from: number, listSize: number = 10): Promise<IChainBlockInfoResponse[]> => {
-    const promises: Promise<IChainBlockInfoResponse>[] = []
+
+  blockList = (from: number, listSize: number = 10): Promise<Array<IChainBlockInfoResponse | BlockNotFoundError>> => {
+    const promises: Promise<IChainBlockInfoResponse | BlockNotFoundError>[] = []
     // If is not a number bigger than 0
     if (isNaN(from)) return Promise.all(promises)
     for (let i = 0; i < listSize; i++) {
-      if (from + i > 0) promises.push(this.blockByHeight(from + i))
+      if (from + i > 0)
+        promises.push(
+          (async () => {
+            try {
+              return await this.blockByHeight(from + i)
+            } catch (error) {
+              if (error instanceof ErrAPI && error.raw?.response?.status === 404) {
+                return { height: from + i } as BlockNotFoundError
+              }
+              throw error // re-throw other errors
+            }
+          })()
+        )
     }
     return Promise.all(promises).then((blockInfo) => {
       // flatten the array[][] into array[]
@@ -55,4 +79,8 @@ export class ExtendedSDKClient extends VocdoniSDKClient {
   blockToDate = (height: number): ReturnType<typeof ChainAPI.blockToDate> => {
     return ChainAPI.blockToDate(this.url, height)
   }
+}
+
+export type BlockNotFoundError = {
+  height: number
 }


### PR DESCRIPTION
On this way we can create a more verbose output for not found blocks when trying to access them by `blockList`. 

This is not necessary at all since Gui told me that they are fixing the way of how old blocks will be indexed, so this should not be necessary anymore on the explorer. But, just in case, the change is not really big and we could use it from now and will prevent future pruned blocks that are not indexed properly. 

The question here is if simply return a more generic error type (not only for the 404 blocks). 