### PR TITLE
Improve blocks errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@testing-library/react": "^15.0.5",
     "@types/jest": "^29.5.3",
     "@types/testing-library__jest-dom": "5.14.8",
-    "axios": "^0.27.0",
     "clean-package": "^2.2.0",
     "eslint-plugin-testing-library": "5.5.1",
     "ethers": "^5.7.0",


### PR DESCRIPTION
It uses error classes that extend `ErrAPI`. On this way is much easier to use `instanceof` to get the type of the error, which is more useful than the declared `type` of before