### PR TITLE
Implement choice metadata

### DIFF
--- a/packages/chakra-components/src/components/Election/Questions/Fields.tsx
+++ b/packages/chakra-components/src/components/Election/Questions/Fields.tsx
@@ -280,11 +280,12 @@ export const QuestionChoice = (choice: IChoice & ChakraProps) => {
   const thumbnail = image?.thumbnail
   const descriptionTxt = description?.default ?? ''
 
-  const renderModal = defaultImage || descriptionTxt || thumbnail
+  const renderImage = defaultImage || thumbnail
+  const renderModal = renderImage || descriptionTxt
 
   return (
     <Stack sx={styles.choiceWrapper}>
-      {(defaultImage || thumbnail) && (
+      {renderImage && (
         <Skeleton isLoaded={loaded} sx={styles.skeleton}>
           <Image
             onClick={(e) => {
@@ -306,9 +307,14 @@ export const QuestionChoice = (choice: IChoice & ChakraProps) => {
           <ModalContent sx={styles.modalContent}>
             <ModalCloseButton sx={styles.modalClose} />
             <ModalBody sx={styles.modalBody}>
-              {defaultImage && (
+              {renderImage && (
                 <Skeleton isLoaded={loadedModal} sx={styles.skeletonModal}>
-                  <Image src={defaultImage} alt={label} sx={styles.modalImage} onLoad={() => setLoadedModal(true)} />
+                  <Image
+                    src={defaultImage ?? thumbnail}
+                    alt={label}
+                    sx={styles.modalImage}
+                    onLoad={() => setLoadedModal(true)}
+                  />
                 </Skeleton>
               )}
               <Text sx={styles.modalLabel}>{label}</Text>

--- a/packages/chakra-components/src/theme/index.ts
+++ b/packages/chakra-components/src/theme/index.ts
@@ -7,6 +7,7 @@ import {
   QuestionsConfirmationTheme,
   QuestionsTipTheme,
   QuestionsTypeBadgeTheme,
+  QuestionsChoiceTheme,
 } from './questions'
 import { ResultsTheme as ElectionResults } from './results'
 import { PaginationTheme as Pagination } from './pagination'
@@ -23,6 +24,7 @@ export const theme = {
     Pagination,
     ConfirmModal: ConfirmModalTheme,
     QuestionsConfirmation: QuestionsConfirmationTheme,
+    QuestionsChoice: QuestionsChoiceTheme,
     QuestionsTip: QuestionsTipTheme,
     QuestionsTypeBadge: QuestionsTypeBadgeTheme,
     VoteWeight: VoteWeightTheme,

--- a/packages/chakra-components/src/theme/questions.ts
+++ b/packages/chakra-components/src/theme/questions.ts
@@ -143,3 +143,52 @@ export const QuestionsTipTheme = defineQuestionTipStyle({
     },
   }),
 })
+
+export const questionChoiceAnatomy = [
+  // Choice Label
+  'choiceLabel',
+  // Image for the choice
+  'choiceImage',
+  // Wrapper for image and label
+  'choiceWrapper',
+  // Skeleton loader for the choice image
+  'skeleton',
+  // Skeleton loader for modal image
+  'skeletonModal',
+  // Modal
+  'modalBody',
+  'modalContent',
+  'modalClose',
+  // Modal description if exists on metadata
+  'modalDescription',
+  // Image on modal
+  'modalImage',
+  // Modal label (choice label)
+  'modalLabel',
+  'modalOverlay',
+]
+
+const { defineMultiStyleConfig: defineQuestionChoiceStyle, definePartsStyle: defineQuestionChoiceParts } =
+  createMultiStyleConfigHelpers(questionChoiceAnatomy)
+
+export const QuestionsChoiceTheme = defineQuestionChoiceStyle({
+  baseStyle: defineQuestionChoiceParts({
+    choiceWrapper: {
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+    modalBody: {
+      p: 0,
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    skeleton: {
+      boxSize: '80px',
+    },
+    skeletonModal: {
+      boxSize: '400px',
+    },
+  }),
+})


### PR DESCRIPTION
It implements a new Component called `QuestionChoice` which is able to render a choice image and a modeal to open the image. 

Choice metadata accepts also choice description

![image](https://github.com/user-attachments/assets/d9eccdce-99cf-44e8-9e75-cfec55447490)

Related https://github.com/vocdoni/ui-scaffold/issues/623
