### PR TITLE
feat: render metadata images and description in choices

### DIFF
--- a/packages/chakra-components/src/components/Election/Questions/Choice.tsx
+++ b/packages/chakra-components/src/components/Election/Questions/Choice.tsx
@@ -1,0 +1,78 @@
+import {
+  Image,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalOverlay,
+  Skeleton,
+  Stack,
+  StackProps,
+  Text,
+  useDisclosure,
+  useMultiStyleConfig,
+} from '@chakra-ui/react'
+import { IChoice } from '@vocdoni/sdk'
+import { useState } from 'react'
+import { QuestionChoiceAnatomyRecord } from '../../../theme/question-choice'
+
+export type QuestionChoiceMeta = {
+  image: {
+    default: string
+    thumbnail?: string
+  }
+  description?: {
+    default: string
+    [lang: string]: string
+  }
+}
+
+export const QuestionChoice = ({ choice, ...rest }: { choice: IChoice } & StackProps) => {
+  const styles = useMultiStyleConfig('QuestionChoice') as QuestionChoiceAnatomyRecord
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  const [loaded, setLoaded] = useState(false)
+  const [loadedModal, setLoadedModal] = useState(false)
+
+  const label = choice.title.default
+  const { image, description } = ((choice as any)?.meta ?? {}) as QuestionChoiceMeta
+  const renderImage = !!image.default
+  const renderModal = image.default && image.thumbnail
+
+  return (
+    <Stack sx={styles.wrapper} {...rest}>
+      {renderImage && (
+        <Skeleton isLoaded={loaded} sx={styles.skeleton}>
+          <Image
+            onClick={(e) => {
+              if (!renderModal) return
+              e.preventDefault()
+              onOpen()
+            }}
+            sx={styles.image}
+            src={image.thumbnail ?? image.default}
+            alt={label}
+            onLoad={() => setLoaded(true)}
+          />
+        </Skeleton>
+      )}
+      <Text sx={styles.label}>{label}</Text>
+      {renderModal && (
+        <Modal isOpen={isOpen} onClose={onClose}>
+          <ModalOverlay sx={styles.modalOverlay} />
+          <ModalContent sx={styles.modalContent}>
+            <ModalCloseButton sx={styles.modalClose} />
+            <ModalBody sx={styles.modalBody}>
+              {renderImage && (
+                <Skeleton isLoaded={loadedModal} sx={styles.skeletonModal}>
+                  <Image src={image.default} alt={label} sx={styles.modalImage} onLoad={() => setLoadedModal(true)} />
+                </Skeleton>
+              )}
+              <Text sx={styles.modalLabel}>{label}</Text>
+              {description && <Text sx={styles.modalDescription}>{description.default}</Text>}
+            </ModalBody>
+          </ModalContent>
+        </Modal>
+      )}
+    </Stack>
+  )
+}

--- a/packages/chakra-components/src/components/Election/Questions/Choice.tsx
+++ b/packages/chakra-components/src/components/Election/Questions/Choice.tsx
@@ -14,29 +14,25 @@ import {
 } from '@chakra-ui/react'
 import { IChoice } from '@vocdoni/sdk'
 import { useState } from 'react'
-import { QuestionChoiceAnatomyRecord } from '../../../theme/question-choice'
 
 export type QuestionChoiceMeta = {
   image: {
     default: string
     thumbnail?: string
   }
-  description?: {
-    default: string
-    [lang: string]: string
-  }
+  description?: string
 }
 
 export const QuestionChoice = ({ choice, ...rest }: { choice: IChoice } & StackProps) => {
-  const styles = useMultiStyleConfig('QuestionChoice') as QuestionChoiceAnatomyRecord
+  const styles = useMultiStyleConfig('QuestionChoice')
   const { isOpen, onOpen, onClose } = useDisclosure()
   const [loaded, setLoaded] = useState(false)
   const [loadedModal, setLoadedModal] = useState(false)
 
   const label = choice.title.default
-  const { image, description } = ((choice as any)?.meta ?? {}) as QuestionChoiceMeta
-  const renderImage = !!image.default
-  const renderModal = image.default && image.thumbnail
+  const { image, description } = (choice.meta ?? {}) as QuestionChoiceMeta
+  const renderImage = !!image && !!image.default
+  const renderModal = !!image && image.default && image.thumbnail
 
   return (
     <Stack sx={styles.wrapper} {...rest}>
@@ -56,6 +52,7 @@ export const QuestionChoice = ({ choice, ...rest }: { choice: IChoice } & StackP
         </Skeleton>
       )}
       <Text sx={styles.label}>{label}</Text>
+      {description && <Text sx={styles.description}>{description}</Text>}
       {renderModal && (
         <Modal isOpen={isOpen} onClose={onClose}>
           <ModalOverlay sx={styles.modalOverlay} />
@@ -68,7 +65,7 @@ export const QuestionChoice = ({ choice, ...rest }: { choice: IChoice } & StackP
                 </Skeleton>
               )}
               <Text sx={styles.modalLabel}>{label}</Text>
-              {description && <Text sx={styles.modalDescription}>{description.default}</Text>}
+              {description && <Text sx={styles.modalDescription}>{description}</Text>}
             </ModalBody>
           </ModalContent>
         </Modal>

--- a/packages/chakra-components/src/components/Election/Questions/Confirmation.tsx
+++ b/packages/chakra-components/src/components/Election/Questions/Confirmation.tsx
@@ -44,12 +44,13 @@ export const QuestionsConfirmation = ({ answers, election, ...rest }: QuestionsC
                 </chakra.div>
               )
             }
-            const choices = answers[0]
+
+            const choices = (answers[0] || ['-1'])
               .map((a: string) =>
                 q.choices[Number(a)] ? q.choices[Number(a)].title.default : localize('vote.abstain')
               )
               .map((a: string) => (
-                <span>
+                <span key={a}>
                   - {a}
                   <br />
                 </span>

--- a/packages/chakra-components/src/components/Election/Questions/Fields.tsx
+++ b/packages/chakra-components/src/components/Election/Questions/Fields.tsx
@@ -87,7 +87,8 @@ export const MultiChoice = ({ index, question }: QuestionProps) => {
   const choices = [...question.choices]
   // Put can abstain on a separated variable to avoid typing errors on validation function
   const canAbstain = election.resultsType.properties.canAbstain
-  if (canAbstain) {
+  const shouldRenderAbstain = canAbstain && !election.get('questions.hideAbstain')
+  if (canAbstain && shouldRenderAbstain) {
     choices.push({
       title: {
         default: localize('vote.abstain'),
@@ -104,7 +105,7 @@ export const MultiChoice = ({ index, question }: QuestionProps) => {
         rules={{
           validate: (v) => {
             // allow a single selection if is an abstain
-            if (v.includes('-1') && v.length < election.voteType.maxCount!) return true
+            if (!shouldRenderAbstain || (v && v.includes('-1') && v.length < election.voteType.maxCount!)) return true
 
             return (
               (v && v.length === election.voteType.maxCount) ||

--- a/packages/chakra-components/src/components/Election/Questions/Fields.tsx
+++ b/packages/chakra-components/src/components/Election/Questions/Fields.tsx
@@ -13,6 +13,7 @@ import { useElection } from '@vocdoni/react-providers'
 import { ElectionResultsTypeNames, ElectionStatus, IQuestion, PublishedElection } from '@vocdoni/sdk'
 import { Controller, useFormContext } from 'react-hook-form'
 import { Markdown } from '../../layout'
+import { QuestionChoice } from './Choice'
 import { QuestionTip } from './Tip'
 
 export type QuestionProps = {
@@ -140,7 +141,7 @@ export const MultiChoice = ({ index, question }: QuestionProps) => {
                       trigger(index) // Manually trigger validation
                     }}
                   >
-                    {choice.title.default}
+                    <QuestionChoice choice={choice} />
                   </Checkbox>
                 )
               })}
@@ -204,7 +205,7 @@ export const ApprovalChoice = ({ index, question }: QuestionProps) => {
                       }
                     }}
                   >
-                    {choice.title.default}
+                    <QuestionChoice choice={choice} />
                   </Checkbox>
                 )
               })}
@@ -246,7 +247,7 @@ export const SingleChoice = ({ index, question }: QuestionProps) => {
           <Stack direction='column' sx={styles.stack}>
             {question.choices.map((choice, ck) => (
               <Radio key={ck} sx={styles.radio} value={choice.value.toString()}>
-                {choice.title.default}
+                <QuestionChoice choice={choice} />
               </Radio>
             ))}
           </Stack>

--- a/packages/chakra-components/src/components/Election/Questions/Form.tsx
+++ b/packages/chakra-components/src/components/Election/Questions/Form.tsx
@@ -62,8 +62,13 @@ export const QuestionsFormProvider: React.FC<PropsWithChildren<QuestionsFormProv
           .pop()
           .map((v: string) => parseInt(v, 10))
         // map proper abstain ids
-        if (results.includes(-1)) {
-          results.splice(results.indexOf(-1), 1)
+        if (
+          results.includes(-1) ||
+          (election.resultsType.properties.canAbstain && (!values || results.length < election.voteType.maxCount!))
+        ) {
+          if (results.includes(-1)) {
+            results.splice(results.indexOf(-1), 1)
+          }
           let abs = 0
           while (results.length < (election.voteType.maxCount || 1)) {
             results.push(parseInt(election.resultsType.properties.abstainValues[abs++], 10))

--- a/packages/chakra-components/src/theme/question-choice.ts
+++ b/packages/chakra-components/src/theme/question-choice.ts
@@ -1,0 +1,51 @@
+import { createMultiStyleConfigHelpers, SystemStyleObject } from '@chakra-ui/react'
+
+export const questionChoiceAnatomy = [
+  // Choice Label
+  'label',
+  // Image for the choice
+  'image',
+  // Wrapper for image and label
+  'wrapper',
+  // Skeleton loader for the choice image
+  'skeleton',
+  // Skeleton loader for modal image
+  'skeletonModal',
+  // Modal
+  'modalBody',
+  'modalContent',
+  'modalClose',
+  // Modal description if exists on metadata
+  'modalDescription',
+  // Image on modal
+  'modalImage',
+  // Modal label (choice label)
+  'modalLabel',
+  'modalOverlay',
+] as const
+
+export type QuestionChoiceAnatomyRecord = Record<(typeof questionChoiceAnatomy)[number], SystemStyleObject>
+
+const { defineMultiStyleConfig, definePartsStyle } = createMultiStyleConfigHelpers(questionChoiceAnatomy)
+
+export const QuestionChoiceTheme = defineMultiStyleConfig({
+  baseStyle: definePartsStyle({
+    choiceWrapper: {
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+    modalBody: {
+      p: 0,
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    skeleton: {
+      boxSize: '80px',
+    },
+    skeletonModal: {
+      boxSize: '400px',
+    },
+  }),
+})

--- a/packages/chakra-components/src/theme/question-choice.ts
+++ b/packages/chakra-components/src/theme/question-choice.ts
@@ -3,6 +3,7 @@ import { createMultiStyleConfigHelpers, SystemStyleObject } from '@chakra-ui/rea
 export const questionChoiceAnatomy = [
   // Choice Label
   'label',
+  'description',
   // Image for the choice
   'image',
   // Wrapper for image and label


### PR DESCRIPTION
This standardizes* what @selankon did in PR #205. Such PR has not been accepted because it's into another PR that never got approved for not being really required.

From the original PR, some changes have been done:
- The modal will only render if both default and thumbnail images are defined.
- When only default is defined, no modal will be rendered
- Anatomy keys have been renamed for simplicity
- A cast to any was required in choice.meta since the required SDK changes never got an official version
- Added new optional description field that loads both in the choice selection and the modal. 
- Added the option, via meta, to hide the abstain option, but still send it unless the number of votes < maxNumberOfChoices

\* standardized so it can be merged to `main`, rather than to a specific branch with more changes