### PR TITLE
Support configurable pagination base index with initialPage prop

### DIFF
--- a/packages/chakra-components/src/components/Pagination/Pagination.tsx
+++ b/packages/chakra-components/src/components/Pagination/Pagination.tsx
@@ -26,8 +26,8 @@ type PaginatorButtonProps = {
   pageIndex?: number
 } & ButtonProps
 
-const PageButton = ({ page, currentPage, ...rest }: PaginatorButtonProps) => (
-  <PaginatorButton isActive={currentPage === page} {...rest}>
+const PageButton = ({ page, pageIndex, currentPage, ...rest }: PaginatorButtonProps) => (
+  <PaginatorButton isActive={currentPage === pageIndex} {...rest}>
     {page + 1}
   </PaginatorButton>
 )
@@ -156,17 +156,28 @@ const PaginationButtons = ({
 }
 
 export const Pagination = ({ maxButtons = 10, buttonProps, inputProps, pagination, ...rest }: PaginationProps) => {
-  const { setPage } = usePagination()
-  const totalPages = pagination.lastPage + 1
-  const page = pagination.currentPage
+  const { page, setPage, initialPage } = usePagination()
+
+  const totalPages = initialPage === 0 ? pagination.lastPage + 1 : pagination.lastPage
+  const currentPage = initialPage === 0 ? page - 1 : page
 
   return (
     <PaginationButtons
       goToPage={(page) => setPage(page)}
-      createPageButton={(i) => (
-        <PageButton key={i} page={i} currentPage={page} onClick={() => setPage(i)} {...buttonProps} />
-      )}
-      currentPage={page}
+      createPageButton={(i) => {
+        const pageIndex = initialPage === 0 ? i : i + initialPage
+        return (
+          <PageButton
+            key={i}
+            onClick={() => setPage(pageIndex)}
+            pageIndex={pageIndex}
+            page={i}
+            currentPage={currentPage}
+            {...buttonProps}
+          />
+        )
+      }}
+      currentPage={currentPage}
       totalPages={totalPages}
       totalItems={pagination.totalItems}
       maxButtons={maxButtons}

--- a/packages/chakra-components/src/components/Pagination/Pagination.tsx
+++ b/packages/chakra-components/src/components/Pagination/Pagination.tsx
@@ -23,6 +23,7 @@ export type PaginationProps = ButtonGroupProps & {
 type PaginatorButtonProps = {
   page: number
   currentPage: number
+  pageIndex?: number
 } & ButtonProps
 
 const PageButton = ({ page, currentPage, ...rest }: PaginatorButtonProps) => (
@@ -32,8 +33,8 @@ const PageButton = ({ page, currentPage, ...rest }: PaginatorButtonProps) => (
 )
 PageButton.displayName = 'PageButton'
 
-const RoutedPageButton = ({ page, currentPage, to, ...rest }: PaginatorButtonProps & { to: string }) => (
-  <PaginatorButton as={RouterLink} to={to} isActive={currentPage === page} {...rest}>
+const RoutedPageButton = ({ page, pageIndex, currentPage, to, ...rest }: PaginatorButtonProps & { to: string }) => (
+  <PaginatorButton as={RouterLink} to={to} isActive={currentPage === pageIndex} {...rest}>
     {page + 1}
   </PaginatorButton>
 )
@@ -176,17 +177,27 @@ export const Pagination = ({ maxButtons = 10, buttonProps, inputProps, paginatio
 Pagination.displayName = 'Pagination'
 
 export const RoutedPagination = ({ maxButtons = 10, buttonProps, pagination, ...rest }: PaginationProps) => {
-  const { getPathForPage, setPage, page } = useRoutedPagination()
+  const { getPathForPage, setPage, page, initialPage } = useRoutedPagination()
 
-  const totalPages = pagination.lastPage + 1
-  const currentPage = page
+  const totalPages = initialPage === 0 ? pagination.lastPage + 1 : pagination.lastPage
+  const currentPage = initialPage === 0 ? page - 1 : page
 
   return (
     <PaginationButtons
       goToPage={(page) => setPage(page)}
-      createPageButton={(i) => (
-        <RoutedPageButton key={i} to={getPathForPage(i + 1)} page={i} currentPage={page} {...buttonProps} />
-      )}
+      createPageButton={(i) => {
+        const pageIndex = initialPage === 0 ? i : i + initialPage
+        return (
+          <RoutedPageButton
+            key={i}
+            to={getPathForPage(i + 1)}
+            pageIndex={pageIndex}
+            page={i}
+            currentPage={currentPage}
+            {...buttonProps}
+          />
+        )
+      }}
       currentPage={currentPage}
       totalPages={totalPages}
       totalItems={pagination.totalItems}

--- a/packages/react-providers/src/pagination/PaginationProvider.tsx
+++ b/packages/react-providers/src/pagination/PaginationProvider.tsx
@@ -5,13 +5,13 @@ import { generatePath, useLocation, useNavigate, useParams } from 'react-router-
 export type PaginationContextProps = {
   page: number
   setPage: (page: number) => void
+  initialPage?: number
   pagination: PaginationResponse['pagination']
 }
 
 export type RoutedPaginationContextProps = Omit<PaginationContextProps, 'setPage'> & {
   path: string
   pagination: PaginationResponse['pagination']
-  initialPage?: number
   // Util function that generates the path for a given page
   // (it return the actual path with queryParams and other route params but changing the page)
   getPathForPage: (page: number, queryParams?: string) => string
@@ -75,8 +75,12 @@ export const RoutedPaginationProvider = ({
   )
 }
 
-export const PaginationProvider = ({ pagination, ...rest }: PropsWithChildren<PaginationProviderProps>) => {
-  const [page, setPage] = useState<number>(0)
+export const PaginationProvider = ({
+  pagination,
+  initialPage = 0,
+  ...rest
+}: PropsWithChildren<PaginationProviderProps>) => {
+  const [page, setPage] = useState<number>(initialPage)
 
-  return <PaginationContext.Provider value={{ page, setPage, pagination }} {...rest} />
+  return <PaginationContext.Provider value={{ page, setPage, pagination, initialPage }} {...rest} />
 }

--- a/packages/react-providers/src/pagination/PaginationProvider.tsx
+++ b/packages/react-providers/src/pagination/PaginationProvider.tsx
@@ -11,6 +11,7 @@ export type PaginationContextProps = {
 export type RoutedPaginationContextProps = Omit<PaginationContextProps, 'setPage'> & {
   path: string
   pagination: PaginationResponse['pagination']
+  initialPage?: number
   // Util function that generates the path for a given page
   // (it return the actual path with queryParams and other route params but changing the page)
   getPathForPage: (page: number, queryParams?: string) => string
@@ -38,6 +39,7 @@ export const useRoutedPagination = (): RoutedPaginationContextProps => {
 
 export type PaginationProviderProps = {
   pagination: PaginationResponse['pagination']
+  initialPage?: number
 }
 
 export type RoutedPaginationProviderProps = PaginationProviderProps & {
@@ -47,11 +49,12 @@ export type RoutedPaginationProviderProps = PaginationProviderProps & {
 export const RoutedPaginationProvider = ({
   path,
   pagination,
+  initialPage = 0,
   ...rest
 }: PropsWithChildren<RoutedPaginationProviderProps>) => {
   const { search } = useLocation()
   const { page, ...extraParams }: { page?: number } = useParams()
-  const p = page && page > 0 ? page - 1 : 0
+  const p = page && page > 0 ? Number(page) : 0
 
   const navigate = useNavigate()
 
@@ -64,7 +67,12 @@ export const RoutedPaginationProvider = ({
     navigate(getPathForPage(page, queryParams))
   }
 
-  return <RoutedPaginationContext.Provider value={{ page: p, path, getPathForPage, setPage, pagination }} {...rest} />
+  return (
+    <RoutedPaginationContext.Provider
+      value={{ page: p, path, getPathForPage, setPage, pagination, initialPage }}
+      {...rest}
+    />
+  )
 }
 
 export const PaginationProvider = ({ pagination, ...rest }: PropsWithChildren<PaginationProviderProps>) => {


### PR DESCRIPTION
Allow customization of pagination start index via `initialPage` prop, enabling support for both 0-based and 1-based page indexing