### PR TITLE
fix(react-components): gate CSP votes on real bundle membership

### DIFF
--- a/packages/react-components/src/components/Election/VoteWeight.tsx
+++ b/packages/react-components/src/components/Election/VoteWeight.tsx
@@ -4,6 +4,7 @@ import { up } from 'up-fetch'
 import { useComponents } from '~components/context/useComponents'
 import { useReactComponentsLocalize } from '~i18n/localize'
 import { useElection } from '~providers'
+import { fetchCheckMembership } from '~providers/csp'
 import { results } from './Results'
 
 const upfetch = up(fetch)
@@ -37,10 +38,21 @@ export const VoteWeight = () => {
           const decimals = (election.meta as any)?.token?.decimals || 0
           setWeight(results(Number(proof.weight), decimals))
         } else {
-          const { weight } = await upfetch<{ weight: string }>(`${election.census.censusURI}/weight`, {
-            method: 'POST',
-            body: { authToken: token },
+          // The bundle /check endpoint returns the voter weight alongside the
+          // membership result, so prefer it and only fall back to the dedicated
+          // /weight endpoint when it doesn't carry a weight.
+          const check = await fetchCheckMembership({
+            endpoint: election.census.censusURI,
+            authToken: token as string,
+            electionId: election.id,
           })
+          let weight = check.belongs ? check.weight : undefined
+          if (typeof weight === 'undefined') {
+            ;({ weight } = await upfetch<{ weight: string }>(`${election.census.censusURI}/weight`, {
+              method: 'POST',
+              body: { authToken: token },
+            }))
+          }
           setWeight(results(Number.parseInt(weight, 16)))
         }
       } catch (error) {

--- a/packages/react-components/src/providers/csp/index.test.ts
+++ b/packages/react-components/src/providers/csp/index.test.ts
@@ -1,5 +1,5 @@
 import { CensusType, CspProofType, PublishedElection, VocdoniSDKClient, Vote, WeightedCensus } from '@vocdoni/sdk'
-import { vote } from './index'
+import { fetchCheckMembership, vote } from './index'
 
 const { upFetchMock } = vi.hoisted(() => ({
   upFetchMock: vi.fn(),
@@ -45,5 +45,38 @@ describe('csp vote', () => {
     expect(vid).toBe('vote-id')
     expect(client.cspVote).toHaveBeenCalledWith(expect.any(Vote), 'sig', CspProofType.ECDSA_PIDSALTED)
     expect(client.submitVote).toHaveBeenCalledWith(expect.objectContaining({ weight: BigInt(10) }))
+  })
+})
+
+describe('fetchCheckMembership', () => {
+  beforeEach(() => {
+    upFetchMock.mockReset()
+  })
+
+  it('posts to the bundle ${censusURI}/check endpoint with token and electionId', async () => {
+    upFetchMock.mockResolvedValue({ belongs: true, weight: '0a', hasVoted: false })
+
+    const result = await fetchCheckMembership({
+      endpoint: 'https://csp.example/process/bundle/abc',
+      authToken: 'token',
+      electionId: 'election-1',
+    })
+
+    expect(upFetchMock).toHaveBeenCalledWith('https://csp.example/process/bundle/abc/check', {
+      method: 'POST',
+      body: { authToken: 'token', electionId: 'election-1' },
+    })
+    expect(result).toEqual({ belongs: true, weight: '0a', hasVoted: false })
+  })
+
+  it('omits electionId from the body when not provided', async () => {
+    upFetchMock.mockResolvedValue({ belongs: false, hasVoted: false })
+
+    await fetchCheckMembership({ endpoint: 'https://csp.example/process/bundle/abc', authToken: 'token' })
+
+    expect(upFetchMock).toHaveBeenCalledWith('https://csp.example/process/bundle/abc/check', {
+      method: 'POST',
+      body: { authToken: 'token' },
+    })
   })
 })

--- a/packages/react-components/src/providers/csp/index.ts
+++ b/packages/react-components/src/providers/csp/index.ts
@@ -51,3 +51,28 @@ export const fetchSignInfo = ({
     method: 'POST',
     body: { authToken },
   })
+
+type CheckMembershipResponse = {
+  belongs: boolean
+  weight?: string // hex
+  hasVoted: boolean
+}
+
+type CheckMembershipMutationVariables = {
+  endpoint: string
+  authToken: string
+  electionId?: string
+}
+
+// Posts to ${endpoint}/check, where endpoint is the bundle base
+// (the same base used by /sign and /weight, i.e. census.censusURI), which
+// resolves to POST /process/bundle/{bundleId}/check on the backend.
+export const fetchCheckMembership = ({
+  endpoint,
+  authToken,
+  electionId,
+}: CheckMembershipMutationVariables): Promise<CheckMembershipResponse> =>
+  f(`${endpoint}/check`, {
+    method: 'POST',
+    body: { authToken, ...(electionId ? { electionId } : {}) },
+  })

--- a/packages/react-components/src/providers/election/ElectionProvider.test.tsx
+++ b/packages/react-components/src/providers/election/ElectionProvider.test.tsx
@@ -4,7 +4,7 @@ import { CensusType, EnvOptions, PublishedElection, VocdoniSDKClient, WeightedCe
 import { act } from 'react'
 import * as browserModule from '~providers/browser'
 import { ClientContext, ClientProvider, useClient } from '~providers/client'
-import { fetchSignInfo } from '~providers/csp'
+import { fetchCheckMembership, fetchSignInfo } from '~providers/csp'
 import { TestProvider, onlyProps, properProps } from '~providers/test-utils'
 import * as webWorkerModule from '~providers/worker/webWorker'
 import { ElectionProvider, useElection } from './ElectionProvider'
@@ -17,6 +17,7 @@ vi.mock('~providers/csp', () => ({
       at: new Date().toISOString(),
     })
   ),
+  fetchCheckMembership: vi.fn(() => Promise.resolve({ belongs: true, hasVoted: false })),
   vote: vi.fn(),
 }))
 
@@ -24,6 +25,8 @@ describe('<ElectionProvider />', () => {
   beforeEach(() => {
     localStorage.removeItem('csp_token')
     vi.mocked(fetchSignInfo).mockClear()
+    vi.mocked(fetchCheckMembership).mockClear()
+    vi.mocked(fetchCheckMembership).mockResolvedValue({ belongs: true, hasVoted: false })
   })
 
   it('renders child elements', () => {
@@ -872,6 +875,64 @@ describe('<ElectionProvider />', () => {
     expect(result.current.isInCensus).toBeTruthy()
     expect(result.current.isAbleToVote).toBeTruthy()
     expect(result.current.votesLeft).toBe(1)
+
+    localStorage.removeItem('csp_token')
+  })
+
+  it('gates CSP voters out of census when bundle check reports they do not belong', async () => {
+    localStorage.setItem('csp_token', 'token')
+    vi.mocked(fetchCheckMembership).mockResolvedValue({ belongs: false, hasVoted: false })
+
+    const signer = Wallet.createRandom()
+    const client = new VocdoniSDKClient({
+      env: EnvOptions.STG,
+      wallet: signer,
+    })
+    client.voteService.info = vi.fn().mockResolvedValue({ voteID: null, overwriteCount: 0 })
+
+    const census = new WeightedCensus()
+    census.type = CensusType.CSP
+    census.censusURI = 'https://csp.example/api'
+
+    // @ts-ignore
+    const election = PublishedElection.build({
+      id: 'csp-election-not-belonging',
+      title: 'test',
+      description: 'test',
+      endDate: new Date(),
+      census,
+      electionType: { anonymous: false },
+      voteType: { maxVoteOverwrites: 0, maxCount: 1, maxValue: 1 },
+    })
+
+    const wrapper = (props: any) => {
+      return (
+        <TestProvider>
+          <ClientProvider {...onlyProps(props)}>
+            <ElectionProvider {...properProps(props)} />
+          </ClientProvider>
+        </TestProvider>
+      )
+    }
+
+    const { result } = renderHook(() => useElection(), {
+      wrapper,
+      initialProps: { election, fetchCensus: true, client, signer },
+    })
+
+    await waitFor(() => {
+      expect(result.current.loaded.census).toBeTruthy()
+    })
+
+    expect(fetchCheckMembership).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: 'https://csp.example/api',
+        authToken: 'token',
+        electionId: 'csp-election-not-belonging',
+      })
+    )
+    expect(result.current.isInCensus).toBeFalsy()
+    expect(result.current.isAbleToVote).toBeFalsy()
 
     localStorage.removeItem('csp_token')
   })

--- a/packages/react-components/src/providers/election/ElectionProvider.test.tsx
+++ b/packages/react-components/src/providers/election/ElectionProvider.test.tsx
@@ -24,8 +24,15 @@ vi.mock('~providers/csp', () => ({
 describe('<ElectionProvider />', () => {
   beforeEach(() => {
     localStorage.removeItem('csp_token')
-    vi.mocked(fetchSignInfo).mockClear()
-    vi.mocked(fetchCheckMembership).mockClear()
+    // mockReset (not mockClear) drains any *Once queued implementations so they
+    // can't leak into later tests, then we re-establish the default behaviour.
+    vi.mocked(fetchSignInfo).mockReset()
+    vi.mocked(fetchSignInfo).mockResolvedValue({
+      address: '0x0',
+      nullifier: '0xdeadbeef',
+      at: new Date().toISOString(),
+    })
+    vi.mocked(fetchCheckMembership).mockReset()
     vi.mocked(fetchCheckMembership).mockResolvedValue({ belongs: true, hasVoted: false })
   })
 
@@ -937,9 +944,7 @@ describe('<ElectionProvider />', () => {
     localStorage.removeItem('csp_token')
   })
 
-  it('enables voting when CSP token is set after initial render and sign-info returns 401', async () => {
-    vi.mocked(fetchSignInfo).mockRejectedValueOnce({ status: 401 })
-
+  it('enables voting when the CSP token is set after the initial render', async () => {
     const client = new VocdoniSDKClient({
       env: EnvOptions.STG,
     })
@@ -986,9 +991,9 @@ describe('<ElectionProvider />', () => {
     expect(result.current.isAbleToVote).toBeTruthy()
   })
 
-  it('treats 401 on CSP sign info as no prior vote', async () => {
+  it('grants full allowance to a CSP member who has not voted (check hasVoted=false)', async () => {
     localStorage.setItem('csp_token', 'token')
-    vi.mocked(fetchSignInfo).mockRejectedValueOnce({ status: 401 })
+    vi.mocked(fetchCheckMembership).mockResolvedValue({ belongs: true, hasVoted: false })
 
     const signer = Wallet.createRandom()
     const client = new VocdoniSDKClient({
@@ -1002,7 +1007,7 @@ describe('<ElectionProvider />', () => {
 
     // @ts-ignore
     const election = PublishedElection.build({
-      id: 'csp-election-401',
+      id: 'csp-election-not-voted',
       title: 'test',
       description: 'test',
       endDate: new Date(),
@@ -1042,15 +1047,18 @@ describe('<ElectionProvider />', () => {
     })
 
     expect(result.current.election.voted).toBeNull()
-    expect(result.current.election.loaded.voted).toBeFalsy()
     expect(result.current.election.votesLeft).toBe(1)
     expect(result.current.election.isAbleToVote).toBeTruthy()
+    // membership check resolved hasVoted directly, so no nullifier lookup is needed
+    expect(fetchSignInfo).not.toHaveBeenCalled()
 
     localStorage.removeItem('csp_token')
   })
 
   it('sets CSP votesLeft to 0 when vote exists and overwrites are disabled', async () => {
     localStorage.setItem('csp_token', 'token')
+    // hasVoted=true forces the exact-overwrite resolution via the nullifier
+    vi.mocked(fetchCheckMembership).mockResolvedValue({ belongs: true, hasVoted: true })
 
     const signer = Wallet.createRandom()
     const client = new VocdoniSDKClient({
@@ -1167,7 +1175,7 @@ describe('<ElectionProvider />', () => {
     })
 
     await waitFor(() => {
-      expect(result.current.election.loaded.voted).toBeTruthy()
+      expect(result.current.election.isAbleToVote).toBe(false)
     })
 
     expect(result.current.election.isInCensus).toBeFalsy()

--- a/packages/react-components/src/providers/election/use-election-provider.ts
+++ b/packages/react-components/src/providers/election/use-election-provider.ts
@@ -8,7 +8,6 @@ import {
   HasAlreadyVotedOptions,
   PublishedElection,
   Vote,
-  VoteInfoResponse,
   VotesLeftCountOptions,
 } from '@vocdoni/sdk'
 import { ComponentType, useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -20,7 +19,7 @@ import { errorToString } from '~providers/utils'
 import worker, { ICircuit, ICircuitWorkerRequest } from '~providers/worker/circuitWorkerScript'
 import { useWebWorker } from '~providers/worker/useWebWorker'
 import { createWebWorker } from '~providers/worker/webWorker'
-import { ElectionLike, isInvalidElectionLike, isPublishedElectionLike, normalizeElection } from './normalized'
+import { ElectionLike, isPublishedElectionLike, normalizeElection } from './normalized'
 import { useElectionReducer } from './use-election-reducer'
 
 export type ElectionProviderProps = {
@@ -156,6 +155,45 @@ export const useElectionProvider = ({
     [actions, client, currentElectionId, electionQuery, queryClient]
   )
 
+  // Resolves voted/votesLeft for a CSP voter known to belong to the census.
+  // The bundle /check endpoint only reports a boolean hasVoted, so the exact
+  // remaining-overwrites count is resolved via the nullifier only when needed.
+  const resolveCspVoteStatus = useCallback(
+    async (
+      election: { id: string; census: { censusURI: string }; voteType?: { maxVoteOverwrites?: number } },
+      token: string,
+      hasVoted: boolean
+    ) => {
+      const maxVoteOverwrites = election.voteType?.maxVoteOverwrites ?? 0
+
+      // Not voted yet: full allowance, no nullifier lookup required.
+      if (!hasVoted) {
+        actions.votesLeft(maxVoteOverwrites + 1)
+        setVoted(null)
+        return
+      }
+
+      // Voted: resolve the exact remaining overwrites through the nullifier.
+      try {
+        const uri = new URL(election.census.censusURI)
+        const endpoint = `${uri.protocol}//${uri.host}`
+        const signInfo = await fetchSignInfo({ endpoint, authToken: token, processId: election.id })
+        const voteInfo = await client.voteService.info(signInfo.nullifier)
+        const voteId = voteInfo?.voteID ?? null
+        const overwriteCount = voteInfo?.overwriteCount ?? 0
+        const votesLeft = voteId ? Math.max(0, maxVoteOverwrites - overwriteCount) : maxVoteOverwrites + 1
+        actions.votesLeft(votesLeft)
+        setVoted(voteId)
+      } catch (e) {
+        console.error('error resolving csp vote status:', e)
+        // /check already told us the voter has voted; without overwrite details
+        // assume no overwrites remain (votesLeft already defaults to 0).
+        setVoted(null)
+      }
+    },
+    [actions, client, setVoted]
+  )
+
   const censusFetch = useCallback(async () => {
     const address = await client.wallet?.getAddress()
     if (!isPublishedElectionLike(election)) return
@@ -176,15 +214,19 @@ export const useElectionProvider = ({
         // CSP membership is gated on the bundle/check endpoint: a token alone
         // does not imply the voter belongs to *this* election's census.
         lastCspCensusToken.current = state.csp.token
-        isIn = state.csp.token
-          ? (
-              await fetchCheckMembership({
-                endpoint: election.census.censusURI,
-                authToken: state.csp.token,
-                electionId: election.id,
-              })
-            ).belongs
-          : false
+        if (state.csp.token) {
+          const check = await fetchCheckMembership({
+            endpoint: election.census.censusURI,
+            authToken: state.csp.token,
+            electionId: election.id,
+          })
+          isIn = check.belongs
+          if (check.belongs) {
+            await resolveCspVoteStatus(election as PublishedElection, state.csp.token, check.hasVoted)
+          }
+        } else {
+          isIn = false
+        }
       } else {
         isIn = await client.isInCensus({ electionId: election.id })
       }
@@ -211,7 +253,7 @@ export const useElectionProvider = ({
       setLoading((prev) => ({ ...prev, census: false }))
       setLoaded((prev) => ({ ...prev, census: true }))
     }
-  }, [actions, client, election, password, signature, setIsAbleToVote, setVoted, state.csp.token])
+  }, [actions, client, election, password, signature, setIsAbleToVote, setVoted, resolveCspVoteStatus, state.csp.token])
 
   const { result: circuits, startProcessing } = useWebWorker<ICircuit, ICircuitWorkerRequest>(workerInstance)
 
@@ -354,54 +396,6 @@ export const useElectionProvider = ({
     signature,
     initialElectionId,
   ])
-
-  // csp check sign info (check if voter already voted)
-  useEffect(() => {
-    if (!state.csp.token || !election || !loaded.election || isInvalidElectionLike(election)) return
-    ;(async () => {
-      try {
-        // NOTE: membership (isInCensus) is decided by censusFetch via the
-        // bundle /check endpoint; this effect only resolves voted/votesLeft and
-        // must not assume the voter belongs to the census.
-        const uri = new URL(election.census.censusURI)
-        const endpoint = `${uri.protocol}//${uri.host}`
-        let nullifier: string | null = null
-        try {
-          const signInfo = await fetchSignInfo({
-            endpoint,
-            authToken: state.csp.token,
-            processId: election.id,
-          })
-          nullifier = signInfo.nullifier
-        } catch (error) {
-          const status = error?.status ?? error?.response?.status ?? error?.cause?.status
-          if (Number(status) === 401) {
-            const maxVoteOverwrites = election.voteType?.maxVoteOverwrites ?? 0
-            actions.votesLeft(maxVoteOverwrites + 1)
-            return
-          }
-          throw error
-        }
-
-        let voteInfo: VoteInfoResponse | null = null
-        try {
-          voteInfo = await client.voteService.info(nullifier)
-        } catch (e) {
-          voteInfo = null
-        }
-
-        const voteId = voteInfo?.voteID ?? null
-        const overwriteCount = voteInfo?.overwriteCount ?? 0
-        const maxVoteOverwrites = election.voteType?.maxVoteOverwrites ?? 0
-        const votesLeft = voteId ? Math.max(0, maxVoteOverwrites - overwriteCount) : maxVoteOverwrites + 1
-
-        actions.votesLeft(votesLeft)
-        setVoted(voteId)
-      } catch (e) {
-        console.error('error in csp sign info check:', e)
-      }
-    })()
-  }, [state.csp.token, election, loaded.election, setVoted, actions])
 
   // context vote function (the one to be used with the given components)
   const vote = async (values: number[]) => {

--- a/packages/react-components/src/providers/election/use-election-provider.ts
+++ b/packages/react-components/src/providers/election/use-election-provider.ts
@@ -362,7 +362,9 @@ export const useElectionProvider = ({
     if (!fetchCensus || !election || !loaded.election || loading.census || !client.wallet) return
     ;(async () => {
       const address = await client.wallet?.getAddress()
-      const isCsp = isPublishedElectionLike(election) && (election as { census?: { type?: CensusType } }).census?.type === CensusType.CSP
+      const isCsp =
+        isPublishedElectionLike(election) &&
+        (election as { census?: { type?: CensusType } }).census?.type === CensusType.CSP
       // re-resolve CSP membership whenever the auth token changes (hydration,
       // login, bundle switch, logout) since gating depends on /check
       const cspTokenChanged = isCsp && state.csp.token !== lastCspCensusToken.current

--- a/packages/react-components/src/providers/election/use-election-provider.ts
+++ b/packages/react-components/src/providers/election/use-election-provider.ts
@@ -14,7 +14,7 @@ import {
 import { ComponentType, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { canUseWorkers } from '~providers/browser'
 import { useClient } from '~providers/client'
-import { vote as cspVote, fetchSignInfo } from '~providers/csp'
+import { vote as cspVote, fetchCheckMembership, fetchSignInfo } from '~providers/csp'
 import { queryKeys } from '~providers/query/keys'
 import { errorToString } from '~providers/utils'
 import worker, { ICircuit, ICircuitWorkerRequest } from '~providers/worker/circuitWorkerScript'
@@ -93,6 +93,10 @@ export const useElectionProvider = ({
   })
 
   const isAnonCircuitsFetching = useRef(false)
+  // Tracks the CSP token the census membership (/check) was last resolved for,
+  // so censusFetch re-runs when the token is hydrated/changed (login, bundle
+  // switch, logout) instead of relying on a stale early run.
+  const lastCspCensusToken = useRef<string | undefined>(undefined)
   const [workerInstance, setWorkerInstance] = useState<Worker | null>(null)
 
   const setVoted = useCallback(
@@ -167,7 +171,23 @@ export const useElectionProvider = ({
       const censusType = current.census?.type
       const isAnonymousElection = !!current.electionType?.anonymous
       const isCsp = censusType === CensusType.CSP
-      const isIn = isCsp ? !!state.csp.token : await client.isInCensus({ electionId: election.id })
+      let isIn: boolean
+      if (isCsp) {
+        // CSP membership is gated on the bundle/check endpoint: a token alone
+        // does not imply the voter belongs to *this* election's census.
+        lastCspCensusToken.current = state.csp.token
+        isIn = state.csp.token
+          ? (
+              await fetchCheckMembership({
+                endpoint: election.census.censusURI,
+                authToken: state.csp.token,
+                electionId: election.id,
+              })
+            ).belongs
+          : false
+      } else {
+        isIn = await client.isInCensus({ electionId: election.id })
+      }
       actions.inCensus(isIn)
 
       const requestData: HasAlreadyVotedOptions | VotesLeftCountOptions = {
@@ -300,6 +320,10 @@ export const useElectionProvider = ({
     if (!fetchCensus || !election || !loaded.election || loading.census || !client.wallet) return
     ;(async () => {
       const address = await client.wallet?.getAddress()
+      const isCsp = isPublishedElectionLike(election) && (election as { census?: { type?: CensusType } }).census?.type === CensusType.CSP
+      // re-resolve CSP membership whenever the auth token changes (hydration,
+      // login, bundle switch, logout) since gating depends on /check
+      const cspTokenChanged = isCsp && state.csp.token !== lastCspCensusToken.current
       // The condition is just negated so we can return the code execution.
       // A less mental option is to not negate the entire condition and add
       // the `await censusFetch()` execution in there
@@ -309,7 +333,8 @@ export const useElectionProvider = ({
           !areEqualHexStrings(state.voter, address) ||
           (initialElectionId && !areEqualHexStrings(initialElectionId, election.id)) ||
           // fetch census if there's sik signature and no vote id
-          (signature && !loaded.voted)
+          (signature && !loaded.voted) ||
+          cspTokenChanged
         )
       ) {
         return
@@ -321,6 +346,7 @@ export const useElectionProvider = ({
     fetchCensus,
     client,
     state.voter,
+    state.csp.token,
     loaded.election,
     loading.census,
     actions,
@@ -334,7 +360,9 @@ export const useElectionProvider = ({
     if (!state.csp.token || !election || !loaded.election || isInvalidElectionLike(election)) return
     ;(async () => {
       try {
-        actions.inCensus(true)
+        // NOTE: membership (isInCensus) is decided by censusFetch via the
+        // bundle /check endpoint; this effect only resolves voted/votesLeft and
+        // must not assume the voter belongs to the census.
         const uri = new URL(election.census.censusURI)
         const endpoint = `${uri.protocol}//${uri.host}`
         let nullifier: string | null = null


### PR DESCRIPTION
CSP elections previously treated the mere presence of an auth token as
proof of census membership, so a voter logged in via one bundle could see
the vote button on a CSP election from a different bundle they don't belong
to. Mirror the non-CSP path (client.isInCensus) by resolving membership
against the backend bundle endpoint.

- add fetchCheckMembership() posting to ${censusURI}/check (the bundle base,
  same base used by /sign and /weight) → { belongs, weight?, hasVoted }
- censusFetch now derives isInCensus from belongs (false when no token)
- re-run censusFetch when the CSP token changes (hydration, login, bundle
  switch, logout) via a ref tracking the last checked token
- drop the unconditional inCensus(true) in the sign-info effect, which was
  masking membership; that effect now only resolves voted/votesLeft

Requires https://github.com/vocdoni/saas-backend/pull/505 first to be merged